### PR TITLE
Sometimes $form->getContactID() can't resolve the contact ID 

### DIFF
--- a/frontendpageoptions.php
+++ b/frontendpageoptions.php
@@ -151,7 +151,12 @@ function _frontendpageoptions_processEventForm($form) {
  */
 function _frontendpageoptions_get_redirect_url($url, $form) {
   if (strpos($url, '{') != FALSE) {
-    $contact = civicrm_api3('Contact', 'getsingle', array('id' => $form->getContactID(), 'return' => array('hash)')));
+    $contactId = $form->getContactID();
+    // In some circumstances, $form->getContactID() returns nothing, yet there is a value in $form->_contactID?
+    if (!$contactId && $form->_contactID) {
+      $contactId = $form->_contactID;
+    }
+    $contact = civicrm_api3('Contact', 'getsingle', array('id' => $contactId, 'return' => array('hash)')));
     $url = str_replace('{contact.checksum}', CRM_Contact_BAO_Contact_Utils::generateChecksum(
       $contact['id'],
       NULL,


### PR DESCRIPTION
Sometimes `$form->getContactID()` can't resolve the contact ID even though it's there in `$form->_contactID`, so we can just use that value instead.

I tried to understand [CRM_Core_Form::setContactID()](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Form.php#L1920), but it was clearly doing things above my paygrade.

Or possibly my brain froze when I hit a setFoo() function which takes no parameters.
