### PR TITLE
Closes #4: fix for off-site form processors and events

### DIFF
--- a/frontendpageoptions.php
+++ b/frontendpageoptions.php
@@ -96,7 +96,9 @@ function frontendpageoptions_civicrm_postProcess($formName, &$form) {
   if($formName == 'CRM_Contribute_Form_Contribution_Confirm') {
     _frontendpageoptions_processContributionForm($form);
   }
-  if($formName == 'CRM_Event_Form_Registration_Confirm') {
+  // Don't trigger on an off-site form processor here.
+  if($formName == 'CRM_Event_Form_Registration_Confirm' &&
+    $form->_paymentProcessor['billing_mode'] != CRM_Core_Payment::BILLING_MODE_NOTIFY) {
     _frontendpageoptions_processEventForm($form);
   }
 }
@@ -105,7 +107,7 @@ function frontendpageoptions_civicrm_postProcess($formName, &$form) {
  * implements buildForm hook
  *
  * Since we can't rely on events to always call the confirm page we also take a look
- * when building the thank you pae
+ * when building the thank you page. Also for off-site payment processors.
  * @param string $formName
  * @param \CRM_Core_Form $form
  */


### PR DESCRIPTION
Today I ran into the same problem described by @abbyspenguin.  The key missing detail is that this is for PayPal *Standard*; this extension does a thank-you redirect before the off-site processor.

I made the quick fix for events because there already existed code to trigger the redirect again on the thank-you page; adding support for contributions would follow a similar pattern if someone wants to take it on.